### PR TITLE
Add puzzle7 configuration

### DIFF
--- a/puzzle7.json
+++ b/puzzle7.json
@@ -1,0 +1,32 @@
+{
+  "seats": 8,
+  "executions_to_win": 2,
+  "deck": [
+    "dreamer",
+    "baker",
+    "gemcrafter",
+    "confessor",
+    "scout",
+    "architect",
+    "bombardier",
+    "plague doctor",
+    "shaman",
+    "poisoner"
+  ],
+  "flipped_alignment_counts": {
+    "villager": 4,
+    "outcast": 2,
+    "minion": 2,
+    "demon": 0
+  },
+  "flipped": {
+    "1": { "role": "confessor", "says": "i am dizzy" },
+    "2": { "role": "scout", "says": "shaman is 3 cards away from closest evil" },
+    "3": { "role": "baker", "says": "i was a confessor" },
+    "4": { "role": "confessor", "says": "i am good" },
+    "5": { "role": "gemcrafter", "says": "#2 is good" },
+    "6": { "role": "dreamer" },
+    "7": { "role": "plague doctor" },
+    "8": { "role": "bombardier" }
+  }
+}


### PR DESCRIPTION
## Summary
- add puzzle7.json for an eight-seat scenario with specific deck and alignments

## Testing
- `python demon_bluff_solver.py puzzle7.json | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68bb5e60b6b883269f9ecec6b6dfcf3d