### PR TITLE
Improve Baker statement validation in demon bluff solver

### DIFF
--- a/demon_bluff_solver.py
+++ b/demon_bluff_solver.py
@@ -431,7 +431,13 @@ def evaluate_statements(puzzle, roles, corrupted_set, cure_counts):
             if cond != truth:
                 return False
         elif display == 'baker':
-            # Baker statements are not informative for deduction
+            # Bakers may claim a previous role; only enforce if parseable
+            m = re.search(r'i was (?:a|the) ([a-z ]+)', text)
+            if m:
+                claimed = m.group(1).strip()
+                cond = (role == claimed)
+                if cond != truth:
+                    return False
             continue
         elif display == 'jester':
             nums = re.findall(r'#(\d+)', text)


### PR DESCRIPTION
## Summary
- enforce Baker statements about past roles to match expected truthfulness
- ensures all provided puzzles, including puzzle7, resolve correctly

## Testing
- `python demon_bluff_solver.py puzzle1.json`
- `python demon_bluff_solver.py puzzle2.json`
- `python demon_bluff_solver.py puzzle3.json`
- `python demon_bluff_solver.py puzzle4.json`
- `python demon_bluff_solver.py puzzle5.json`
- `python demon_bluff_solver.py puzzle6.json`
- `python demon_bluff_solver.py puzzle7.json`

------
https://chatgpt.com/codex/tasks/task_e_68bb617e515c8326af901e96f537ce18