### PR TITLE
Add puzzle9 configuration

### DIFF
--- a/puzzles/puzzle9.json
+++ b/puzzles/puzzle9.json
@@ -1,0 +1,31 @@
+{
+  "seats": 8,
+  "executions_to_win": 2,
+  "deck": [
+    "confessor",
+    "architect",
+    "medium",
+    "enlightened",
+    "druid",
+    "oracle",
+    "wretch",
+    "shaman",
+    "witch"
+  ],
+  "flipped_alignment_counts": {
+    "villager": 5,
+    "outcast": 1,
+    "minion": 2,
+    "demon": 0
+  },
+  "flipped": {
+    "1": { "role": "oracle", "says": "#4 or #8 is a witch" },
+    "2": { "role": "medium", "says": "#8 is a real oracle" },
+    "3": { "role": "confessor", "says": "i am good" },
+    "4": { "role": "architect", "says": "right side is more evil" },
+    "5": { "role": "enlightened", "says": "closest evil is equidistant" },
+    "6": { "role": "medium", "says": "#4 is real architect" },
+    "7": { "role": "wretch" },
+    "8": { "role": "unknown", "says": "can not reveal something is blocking me" }
+  }
+}


### PR DESCRIPTION
## Summary
- add puzzle9 with an eight-seat setup and custom roles

## Testing
- `python demon_bluff_solver.py puzzles/puzzle9.json` *(fails: ValueError: No solution found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6ac02cd48326b1e267dbb734f290