### PR TITLE
Add puzzle 9 solution

### DIFF
--- a/solutions/puzzleSolution9.json
+++ b/solutions/puzzleSolution9.json
@@ -1,0 +1,14 @@
+{
+  "seats": 8,
+  "evils_in_play": 2,
+  "solution": {
+    "1": { "role": "oracle", "alignment": "good", "corrupted": false },
+    "2": { "role": "medium", "alignment": "good", "corrupted": false },
+    "3": { "role": "confessor", "alignment": "good", "corrupted": false },
+    "4": { "role": "witch", "alignment": "minion", "corrupted": false },
+    "5": { "role": "enlightened", "alignment": "good", "corrupted": false },
+    "6": { "role": "shaman", "alignment": "minion", "corrupted": false },
+    "7": { "role": "wretch", "alignment": "outcast", "corrupted": false },
+    "8": { "role": "oracle", "alignment": "good", "corrupted": false }
+  }
+}


### PR DESCRIPTION
## Summary
- add JSON solution for puzzle 9 with roles and alignments

## Testing
- `python demon_bluff_solver.py puzzles/puzzle1.json`
- `python demon_bluff_solver.py puzzles/puzzle9.json` *(fails: ValueError: No solution found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6c906b9c8326aa0aea9c3b3f578e